### PR TITLE
Fixed data fetching and pokedex problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,14 @@
-Hey, Kev.
+# What I did
 
-Good morning / good Afternoon!
+- Fetching pokemon only once
+- Fetching pokemon in stores only; the load functions of page.js will just call the functions, this makes it easier to reuse the functions
+- Removed `todos` and `capturados` as we dont need copies of the stores, only makes it harder to maintain code
+- Using `addToPokedex` and `removeFromPokedex` in stores which are just opposite functions the handle stores mutations
 
-Thanks for your quick reply, man! :)
+## General tips
 
-so, here are the tasks.
-
-1.  inside [pokeinfo] you will find page.js and +page.svelte
-
-They load with numbers, if you type somehing like this, in a dynamic order:
-
-http://localhost:5173/2 or http://localhost:5173/34 will work. etc.
-
-In this page.js, I´m fetching data that I already have in a store. In this case, /stores/pokestore.js. So there is no need to another round trip to the pokemon API. I want to use the store instead of fetching again, and of course, make it work with http://localhost:5173/2 dynamics.
-
-2.  Whenever you capture a pokemon, in the home page, it will remove from todos array, and add it to the pokedex store, located in /stores/pokestore.js After capturing, check /pokedex. It will appear there. And this works. Now. the problem is: if I REMOVE from pokedex wallet, it should go back to the todos array, in home page, and re-render in the home page like the initial state. If you try to go back, hitting the back button in the browser, the whole page disappears.
-
-3.  So, to make it short: the user should transfer a pokemon from the home page, to the pokedex page, or revert this operation. From pokedex page to the home page / Data should not be fetched twice / home page shouldnt disappear when back button is clicked.
-
-That all! :)
-
-Let me know if you have any questions! :)
+- Use a Model-View-Controller (MVC) pattern in your code, this sounds harder than it actually is:
+- Try to handle your business logic in store files only like I did now
+- page.js files should only load data and not mutate it => don't handle any greater business logic here
+- .svelte files (Components) should only display the data and only contain UI-logic but not greater business logic
+- 

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,25 +1,8 @@
-
-import { pokesStore, pokesFetching } from '../stores/pokestore';
+import { fetchPokes } from '../stores/pokestore';
 
 export const load = async () => {
-	const fetchPokes = async () => {
-		pokesFetching.set(true);
-		let pokemons = [];
-		let calls = [];
-		for (let i = 1; i < 22; i++) {
-			const call = async () => {
-				const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${i}/`);
-				const data = await res.json();
-				pokemons = [data, ...pokemons];
-			};
-			calls.push(call());
-		}
-		await Promise.all(calls);
-		pokesFetching.set(false);
-		return pokemons;
-	};
-
-	pokesStore.set(await fetchPokes());
+	await fetchPokes();
+	return {};
 };
 
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,37 +1,17 @@
 <script>
-	import { pokesStore, pokesFetching, pokedexStore } from '../stores/pokestore';
-	// console.log($pokesStore[0].types[0].type.name);
+	import {addToPokedex, pokesStore, pokesFetching, pokedexStore} from '../stores/pokestore';
 
-	let bgLtGreen = '#729F92';
-	let bGorange = '#EAAB7D';
-	let bgBlue = '#71C3FF';
-	let bgDkGreen = '#76A866';
-	let bgBrown = '#BF9762';
-
-	let todos = $pokesStore;
-	todos.sort((a, b) => a.id - b.id);
-	let reset = $pokesStore;
-	let capturados = [];
-	capturados.sort((a, b) => a.id - b.id);
-
-	const addPokedex = (id) => {
-		// add to  pokedexStore//
-		let poke = todos.find((poke) => poke.id == id);
-		pokedexStore.update((pokedex) => [...pokedex, poke]);
-		capturados = $pokedexStore;
-		// remove from todos array [which copied content from pokeStore//
-		todos = todos.filter((poke) => poke.id != id);
-	};
-
-	$: pokedexStore.subscribe((pokedex) => {
-		capturados = pokedex;
-	});
+	// let bgLtGreen = '#729F92';
+	// let bGorange = '#EAAB7D';
+	// let bgBlue = '#71C3FF';
+	// let bgDkGreen = '#76A866';
+	// let bgBrown = '#BF9762';
 </script>
 
 <a href="/pokedex">pokedex</a>
 
 <h4>pokedex link status</h4>
-{#each capturados as item}
+{#each $pokedexStore.sort((a, b) => a.id - b.id) as item}
 	<p>captured pokemon id # {item.id} check pokedex route</p>
 {/each}
 
@@ -45,7 +25,7 @@
 {/if}
 
 <div class=" bg-slate-400 container flex flex-row flex-wrap-reverse h-full w-full">
-	{#each todos as poke (poke.id)}
+	{#each $pokesStore.sort((a, b) => a.id - b.id) as poke (poke.id)}
 		<div class="w-[10rem] h-[10rem] rounded-full flex items-center justify-center">
 			<a href="/{poke.id}" data-sveltekit-prefetch><h4>ID# {poke.id}</h4></a>
 			<p>{poke.name}</p>
@@ -54,7 +34,7 @@
 					<h4>{type.type.name}</h4>
 				</div>
 			{/each}
-			<button on:click={() => addPokedex(poke.id)}>Capture!</button>
+			<button on:click={() => addToPokedex(poke.id)}>Capture!</button>
 		</div>
 	{/each}
 </div>

--- a/src/routes/[pokeInfo]/+page.js
+++ b/src/routes/[pokeInfo]/+page.js
@@ -1,9 +1,12 @@
-export const load = ({ fetch, params }) => {
-	const fetchPokemon = async (i) => {
-		const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${i}/`);
-		const data = await response.json();
-		return data;
+import { get } from 'svelte/store';
+import {fetchPokes, pokesStore} from '../../stores/pokestore';
+export const load = async ({ params }) => {
+	const fetchPokemon = (id) => {
+		return get(pokesStore).find(pokemon => pokemon.id == id)
 	};
+	// Ensure pokes are fetched; will not fetch if data already present
+	// We need that in case we open the page directly with the id
+	await fetchPokes();
 	return {
 		pokemon: fetchPokemon(params.pokeInfo)
 	};

--- a/src/routes/[pokeInfo]/+page.svelte
+++ b/src/routes/[pokeInfo]/+page.svelte
@@ -3,5 +3,6 @@
 	const { pokemon } = data;
 </script>
 
+<a href="/">back</a>
 <h4>individual pokemon informations go here!</h4>
 <h2>pokemon name : {pokemon.name}</h2>

--- a/src/routes/pokedex/+page.svelte
+++ b/src/routes/pokedex/+page.svelte
@@ -1,13 +1,5 @@
 <script>
-	import { pokedexStore } from '../../stores/pokestore';
-	let capturados = $pokedexStore;
-	capturados.sort((a, b) => a.id - b.id);
-
-	const handleClick = (id) => {
-		capturados = capturados.filter((poke) => poke.id != id);
-		pokedexStore.set(...capturados);
-		console.log(`limpos`, capturados);
-	};
+	import {removeFromPokedex, pokedexStore} from '../../stores/pokestore';
 </script>
 
 <a href="/">back</a>
@@ -15,13 +7,13 @@
 	pokedex wallet / captured pokemons <br />
 	note that we lost all of the home page data if we go back to home page
 </h4>
-{#each capturados as poke}
+{#each $pokedexStore.sort((a, b) => a.id - b.id) as poke}
 	<p>{poke.name}, {poke.id}</p>
 	<button
-		on:click={() => {
-			handleClick(poke.id);
-		}}
+		on:click={() => removeFromPokedex(poke.id) }
 	>
 		remove from pokedex wallet
 	</button>
+{:else}
+	<p>No pokemon captured yet</p>
 {/each}

--- a/src/stores/pokestore.js
+++ b/src/stores/pokestore.js
@@ -1,5 +1,43 @@
-import { writable } from 'svelte/store';
+import {get, writable} from 'svelte/store';
 
 export const pokesStore = writable([]);
 export const pokedexStore = writable([]);
 export const pokesFetching = writable(false);
+export const pokesFetched = writable(false);
+
+export const fetchPokes = async () => {
+    // Only fetch data once
+	if (get(pokesFetching) || get(pokesFetched)) {
+        return false;
+	}
+    pokesFetching.set(true);
+    let pokemons = [];
+    let calls = [];
+    for (let i = 1; i < 22; i++) {
+        const call = async () => {
+            const res = await fetch(`https://pokeapi.co/api/v2/pokemon/${i}/`);
+            const data = await res.json();
+            pokemons = [data, ...pokemons];
+        };
+        calls.push(call());
+    }
+    await Promise.all(calls);
+    pokesStore.set(pokemons);
+    pokesFetching.set(false);
+    pokesFetched.set(true)
+};
+
+export const addToPokedex = (id) => {
+    // add to pokedexStore
+    const poke = get(pokesStore).find((poke) => poke.id == id);
+    pokedexStore.update((pokedex) => [...pokedex, poke]);
+    // remove from todos array (which copied content from pokeStore)
+    pokesStore.update((pokemons) => pokemons.filter((poke) => poke.id != id));
+};
+
+// Just the opposite of addToPokedex
+export const removeFromPokedex = (id) => {
+    const poke = get(pokedexStore).find((poke) => poke.id == id);
+    pokesStore.update((pokemons) => [...pokemons, poke]);
+    pokedexStore.update((pokedex) => pokedex.filter((poke) => poke.id != id));
+};


### PR DESCRIPTION
- Fetching pokemon only once
- Fetching pokemon in stores only; the load functions of page.js will just call the functions, this makes it easier to reuse the functions
- Removed `todos` and `capturados` as we dont need copies of the stores, only makes it harder to maintain code
- Using `addToPokedex` and `removeFromPokedex` in stores which are just opposite functions the handle stores mutations